### PR TITLE
add light style

### DIFF
--- a/greentext.css
+++ b/greentext.css
@@ -1,3 +1,7 @@
 span.greentext {
     color: rgb(120, 153, 34);
 }
+
+span.greentext-light {
+    color: rgb(184, 217, 98);
+}

--- a/greentext.js
+++ b/greentext.js
@@ -1,13 +1,15 @@
+var greentextClasses = ['greentext', 'greentext-light']
+
 function searcher(node) {
     if (!node) return;
     if ((node.previousSibling == null ||
             node.previousSibling.tagName == 'DIV' ||
-            node.previousSibling.tagName == 'BR') && 
+            node.previousSibling.tagName == 'BR') &&
             node.nodeType == 3 && greentextRegex.test(node.textContent) &&
             !node.parentNode.isContentEditable  &&
             node.parentNode.tagName      != 'A' &&
             node.parentNode.tagName      != 'S' &&
-            node.parentNode.className    != 'greentext' &&
+            !greentextClasses.includes(node.parentNode.className) &&
             node.parentNode.className    != 'quote' ) { // legit greentext on 4chan
             greenTextify(node);
     } else if(node.hasChildNodes()){
@@ -17,17 +19,33 @@ function searcher(node) {
     }
 }
 
+function getNodeColor(node) {
+    var style = getComputedStyle(node);
+    var [, r, g, b] = style.color.match(/rgb\((.*), (.*), (.*)\)/);
+    return { r, g, b };
+}
+
+function isLightColor(originalColor) {
+    var color = originalColor;
+    var a = 1 - (0.299 * color.r + 0.587 * color.g + 0.114 * color.b) / 255;
+    // regular style has perceived brightness of ~0.49 and light of ~0.24
+    // so decide using the midpoint
+    return a < 0.36;
+}
+
 function greenTextify(node) {
     var greenSpan;
-    if (node.previousSibling != null && node.previousSibling.className == "greentext") { // Last node was already greentexted
-        greenSpan = node.previousSibling;
+    if (node.previousSibling != null
+        && greentextClasses.includes(node.previousSibling.className)) { // Last node was already greentexted
+            greenSpan = node.previousSibling;
     } else {
+        var parentColor = getNodeColor(node.parentNode);
         greenSpan = document.createElement('span'); // Create greentext node
-        greenSpan.setAttribute('class', 'greentext'); // Create make span green
+        greenSpan.setAttribute('class', isLightColor(parentColor) ? 'greentext-light' : 'greentext'); // Create make span green
         node.parentNode.insertBefore(greenSpan, node); // Insert span into position
     }
     greenSpan.appendChild(node);
-    
+
     // DON'T USE SPECIAL G+ WORKAROUND ANYMORE
     /* if (greenSpan.nextSibling != null) { // nextSibling exists
         // Special G+ Workaround
@@ -38,7 +56,7 @@ function greenTextify(node) {
 
     if (greenSpan.nextSibling != null && // fuck order of operations holy shit
         (greenSpan.nextSibling.nodeType != 1 ||
-        greenSpan.nextSibling.tagName != 'DIV' && 
+        greenSpan.nextSibling.tagName != 'DIV' &&
         greenSpan.nextSibling.tagName != 'BR')) {
             greenTextify(greenSpan.nextSibling);
     }


### PR DESCRIPTION
The green is often unreadable when it replaces lighter colors. This adds choosing light vs regular style depending on perceived luminance level of the original text.

Previously:
<img width="136" alt="screen shot 2017-10-30 at 10 55 30 pm" src="https://user-images.githubusercontent.com/3967778/32200771-38accc68-bdcb-11e7-982d-ac0db050b539.png">

Now:
<img width="127" alt="screen shot 2017-10-30 at 11 06 25 pm" src="https://user-images.githubusercontent.com/3967778/32200776-41a6553c-bdcb-11e7-875f-c186bd1fd9b6.png">
